### PR TITLE
bug fix for kubernetes (file permission, exposed port)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,5 @@ COPY run-parsoid.sh /run-parsoid.sh
 RUN chmod -v +x /run-parsoid.sh
 
 EXPOSE 8000
+EXPOSE 8001
 CMD ["/run-parsoid.sh"]

--- a/run-parsoid.sh
+++ b/run-parsoid.sh
@@ -101,5 +101,5 @@ do
             domain: '${var:15}'
 EOT
 done
-
+chmod 744 config.yaml
 su -c 'node bin/server.js' $PARSOID_USER


### PR DESCRIPTION
In some kubernetes environments (especially hosted ones) for security reasons the standard permission will be 700 which will cause errors (permission denied) with config.yaml. Moreover it is not allowed to use ports which are not exposed. So also 8001 needs to be exposed because it is used somewhere in parsoid. 