### PR TITLE
improved uri/domain handling

### DIFF
--- a/run-parsoid.sh
+++ b/run-parsoid.sh
@@ -95,10 +95,13 @@ do
         echo >&2 "The $var variable must not be an empty string";
     fi
 
+    uri="${!var}"
+    domain="`echo \"${!var}\" | sed -e 's/[^/]*\/\/\([^@]*@\)\?\([^:/]*\).*/\2/'`"
+
     cat <<EOT >> config.yaml
           -
-            uri: '${!var}'
-            domain: '${var:15}'
+            uri: '$uri'
+            domain: '$domain'
 EOT
 done
 chmod 744 config.yaml


### PR DESCRIPTION
Hello! :smile: 

First of all, I'm really appreciate for your working with parsoid!

I'm using it with my personal wiki and I found a little improvement for it.

If we use it with a domain like below

```
PARSOID_DOMAIN_personal=https://personal.com/w/api.php
```

The request has failed like that

```
$ curl -L http://personal.net:8142/personal.com/v3/page/pagebundle/Main_Page
{"error":"Invalid domain: personal"}
```

IMHO, it is caused by `domain` attribute in config file.

```
mwApis:
  -
    uri: 'https://personal.com/w/api.php'
    domain: 'personal'
```

But in some situations, we should use FQDN for the `domain` attribute and we can meet these requirements with a little changes in this PR.

If you don't mind, Could you consider these changes? :smile: 

Signed-off-by: Ji-Hyeon Gim <potatogim@potatogim.net>